### PR TITLE
fix: add missing `require` export to support commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "import": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
When used inside a CommonJS codebase the import of `tailwind-csstree` fails because of a missing export in `package.json`. This can be fixed by also defining the `require` export in `package.json.`

```sh
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
Error: No "exports" main defined in /home/runner/work/eslint-plugin-better-tailwindcss/eslint-plugin-better-tailwindcss/node_modules/tailwind-csstree/package.json
 ❯ exportsNotFound node:internal/modules/esm/resolve:313:10
 ❯ packageExportsResolve node:internal/modules/esm/resolve:603:13
 ❯ resolveExports node:internal/modules/cjs/loader:650:36
 ❯ Module._findPath node:internal/modules/cjs/loader:717:31
 ❯ Module._resolveFilename node:internal/modules/cjs/loader:1355:27
 ❯ defaultResolveImpl node:internal/modules/cjs/loader:1025:19
 ❯ resolveForCJSWithHooks node:internal/modules/cjs/loader:1030:22
 ❯ Module._load node:internal/modules/cjs/loader:1179:37
 ❯ TracingChannel.traceSync node:diagnostics_channel:322:14
 ❯ wrapModuleLoad node:internal/modules/cjs/loader:235:24

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' }
This error originated in "tests/e2e/commonjs/test.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

Downstream issue: https://github.com/schoero/eslint-plugin-better-tailwindcss/issues/165