### PR TITLE
Fix parsing `@source inline()`

### DIFF
--- a/src/tailwind4.js
+++ b/src/tailwind4.js
@@ -35,7 +35,7 @@ export const tailwind4 = {
             descriptors: defaultSyntax.properties,
         },
         source: {
-            prelude: "<string>",
+            prelude: "not? [ <string> | inline(<string>) ]",
         },
         utility: {
             prelude: "<ident>",

--- a/tests/fixtures/tailwind4.css
+++ b/tests/fixtures/tailwind4.css
@@ -36,6 +36,10 @@
 
 @source "../node_modules/@my-company/ui-lib";
 
+@source inline("{hover:,}bg-red-{50,{100..900..100},950}");
+
+@source not inline('container');
+
 @reference "tailwindcss";
 
 .my-element {


### PR DESCRIPTION
Fixes #18, replaces #19.