### PR TITLE
fix: Move `@eslint/css-tree` to `dependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "tailwind-csstree",
       "version": "0.1.4",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/css-tree": "^3.6.0"
+      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.4",
         "@eslint/css": "^0.8.1",
-        "@eslint/css-tree": "^3.6.0",
         "@eslint/js": "^9.0.0",
         "@tsconfig/node16": "^16.1.1",
         "@types/mocha": "^10.0.3",
@@ -209,7 +211,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.0.tgz",
       "integrity": "sha512-5avBDwDRRjPII9JqiMauDGTmhGcSEsx+NZhkFrWv3RxwMCFccruAGu5N5RFPp4rug9xaZUujLP3jAXByxYDzSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.21.0",
@@ -548,6 +549,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1357,6 +1359,7 @@
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1578,6 +1581,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2521,6 +2525,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2577,7 +2582,6 @@
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
       "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -3651,7 +3655,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4425,6 +4428,7 @@
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
   ],
   "author": "Nicholas C. Zaks",
   "license": "Apache-2.0",
+  "dependencies": {
+    "@eslint/css-tree": "^3.6.0"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@eslint/css": "^0.8.1",
-    "@eslint/css-tree": "^3.6.0",
     "@eslint/js": "^9.0.0",
     "@tsconfig/node16": "^16.1.1",
     "@types/mocha": "^10.0.3",


### PR DESCRIPTION
Using pnpm without hoisting ([`hoist: false`](https://pnpm.io/settings#dependency-hoisting-settings)), I found that this package threw an error.
```
Error: Cannot find module '@eslint/css-tree/definition-syntax-data'
Require stack:
- [...]/node_modules/.pnpm/tailwind-csstree@0.1.4/node_modules/tailwind-csstree/dist/tailwind4.js
```

I original misidentified the error as an error in `@eslint/css-tree` ([apologies](https://github.com/eslint/csstree/issues/105)) and have made the fix here. Apologies for that!

This is where the package is used:
https://github.com/humanwhocodes/tailwind-csstree/blob/9ed0e7085b44dace282b6aa6009bcc068d689dd6/src/tailwind4.js#L10