### PR TITLE
fix: parsing issue in @apply arbitrary bracket classes

### DIFF
--- a/src/node/tailwind-class.js
+++ b/src/node/tailwind-class.js
@@ -48,7 +48,7 @@ export const name = "TailwindUtilityClass";
  */
 export const structure = {
     name: ["Identifier"],
-    variant: ["Identifier"],
+    variant: ["Identifier", null],
 };
 
 /**

--- a/tests/fixtures/tailwind4.css
+++ b/tests/fixtures/tailwind4.css
@@ -12,7 +12,7 @@
 
 @layer components {
   .btn {
-    @apply px-4 py-2 bg-blue-500 text-white dark:text-black;
+    @apply px-4 py-2 bg-blue-500 text-white dark:text-black border-[#222];
   }
 }
 

--- a/tests/tailwind4.test.js
+++ b/tests/tailwind4.test.js
@@ -970,7 +970,7 @@ describe("Tailwind 4", function () {
 
     describe("@apply", () => {
         it("should parse @apply with valid classes", () => {
-            const tree = toPlainObject(parse(".example { @apply bg-red-500 text-white focus:ring-3; }"));
+            const tree = toPlainObject(parse(".example { @apply bg-red-500 text-white focus:ring-3 grid-cols-[200px_auto]; }"));
             assert.deepStrictEqual(tree, {
                 type: "StyleSheet",
                 loc: null,
@@ -1027,6 +1027,16 @@ describe("Tailwind 4", function () {
                                                 name: {
                                                     type: "Identifier",
                                                     name: "ring-3",
+                                                    loc: null
+                                                }
+                                            },
+                                            {
+                                                type: "TailwindUtilityClass",
+                                                loc: null,
+                                                variant: null,
+                                                name: {
+                                                    type: "Identifier",
+                                                    name: "grid-cols-[200px_auto]",
                                                     loc: null
                                                 }
                                             }


### PR DESCRIPTION
## Summary

Fix Tailwind 4 `@apply` handling for arbitrary bracket utilities such as `grid-cols-[200px_auto]`.

## Reproduction

1. Add an arbitrary bracket class like `border-[#222]` to a Tailwind 4 @apply rule in `tests/fixtures/tailwind4.css`
2. Run `npm run test`
3. Observe the walker crash:

```text
TypeError: Cannot read properties of null (reading 'type')
```
## Root Cause

`TailwindUtilityClass.parse()` can return `variant: null` for utilities without a variant prefix, but the node structure declared `variant` as always being an `Identifier`.

That mismatch caused walker-based consumers, such as `toPlainObject()`, to treat `variant` as a required child node and crash when the value was `null`.

## Changes

- Marked `variant` as nullable in the node structure of `TailwindUtilityClass`
- Updated Tailwind 4 test coverage to include a bracketed arbitrary utility in the main `@apply` AST assertion
- Kept fixture coverage for the original failing pattern in the canonical Tailwind 4 fixture