### PR TITLE
fix: add descriptors to utility at-rule

### DIFF
--- a/src/tailwind4.js
+++ b/src/tailwind4.js
@@ -66,6 +66,7 @@ export const tailwind4 = prev => {
 		},
 		utility: {
 			prelude: "<ident>",
+			descriptors: prev.properties,
 		},
 		variant: {
 			prelude: "<ident>",

--- a/tests/tailwind4.test.js
+++ b/tests/tailwind4.test.js
@@ -24,1149 +24,1291 @@ const filename = "./tests/fixtures/tailwind4.css";
 //-----------------------------------------------------------------------------
 
 describe("Tailwind 4", function () {
-    
-    let parse, toPlainObject, lexer;
-    beforeEach(() => {
-        ({ parse, toPlainObject, lexer } = fork(tailwind4));
-    });
+	let parse, toPlainObject, lexer;
+	beforeEach(() => {
+		({ parse, toPlainObject, lexer } = fork(tailwind4));
+	});
 
-    it("tests that tailwind4 is a valid SyntaxExtension", () => {
-        parse("a { color: var(--foo); }");
-    });
-    
-    createThemeFunctionTests(fork(tailwind4));
+	it("tests that tailwind4 is a valid SyntaxExtension", () => {
+		parse("a { color: var(--foo); }");
+	});
 
-    describe("@import", () => {
-        describe("Parsing", () => {
-            it("should parse @import", () => {
-                const tree = toPlainObject(parse("@import 'tailwindcss';"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss",
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with prefix()", () => {
-                const tree = toPlainObject(parse("@import 'tailwindcss' prefix(tw);"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "prefix",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "tw",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with source()", () => {
-                const tree = toPlainObject(parse("@import 'tailwindcss' source('..');"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "source",
-                                        children: [
-                                            {
-                                                type: "String",
-                                                value: "..",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with source(none)", () => {
-                const tree = toPlainObject(parse("@import 'tailwindcss' source(none);"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "source",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "none",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with source and prefix", () => {
-                const tree = toPlainObject(parse("@import 'tailwindcss' source(none) prefix(tw);"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "source",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "none",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "prefix",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "tw",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with source, prefix and layer", () => {
-                const tree = toPlainObject(parse('@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "tailwindcss/utilities.css",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "source",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "none",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "prefix",
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "tw",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    },
-                                    {
-                                        type: "Function",
-                                        name: "layer",
-                                        children: [
-                                            {
-                                                type: "Layer",
-                                                name: "utilities",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with layer", () => {
-                const tree = toPlainObject(parse('@import "./foo.css" layer;'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                children: [
-                                    {
-                                        loc: null,
-                                        type: "String",
-                                        value: "./foo.css"
-                                    },
-                                    {
-                                        loc: null,
-                                        name: "layer",
-                                        type: "Identifier"
-                                    }
-                                ],
-                                loc: null,
-                                type: "AtrulePrelude"
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with layer()", () => {
-                const tree = toPlainObject(parse('@import "./foo.css" layer(utilities);'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                children: [
-                                    {
-                                        loc: null,
-                                        type: "String",
-                                        value: "./foo.css"
-                                    },
-                                    {
-                                        children: [
-                                            {
-                                                loc: null,
-                                                name: "utilities",
-                                                type: "Layer"
-                                            }
-                                        ],
-                                        loc: null,
-                                        name: "layer",
-                                        type: "Function"
-                                    }
-                                ],
-                                loc: null,
-                                type: "AtrulePrelude"
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with media query list", () => {
-                const tree = toPlainObject(parse('@import url("bluish.css") print, screen;'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                children: [
-                                    {
-                                        loc: null,
-                                        type: "Url",
-                                        value: "bluish.css"
-                                    },
-                                    {
-                                        children: [
-                                            {
-                                                condition: null,
-                                                loc: null,
-                                                mediaType: "print",
-                                                modifier: null,
-                                                type: "MediaQuery"
-                                            },
-                                            {
-                                                condition: null,
-                                                loc: null,
-                                                mediaType: "screen",
-                                                modifier: null,
-                                                type: "MediaQuery"
-                                            }
-                                        ],
-                                        loc: null,
-                                        type: "MediaQueryList"
-                                    }
-                                ],
-                                loc: null,
-                                type: "AtrulePrelude"
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-    
-            it("should parse @import with complex media query", () => {
-                const tree = toPlainObject(parse('@import url("landscape.css") screen and (orientation: landscape);'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "import",
-                            prelude: {
-                                children: [
-                                    {
-                                        loc: null,
-                                        type: "Url",
-                                        value: "landscape.css"
-                                    },
-                                    {
-                                        children: [
-                                            {
-                                                condition: {
-                                                    children: [
-                                                        {
-                                                            kind: "media",
-                                                            loc: null,
-                                                            name: "orientation",
-                                                            type: "Feature",
-                                                            value: {
-                                                                loc: null,
-                                                                name: "landscape",
-                                                                type: "Identifier"
-                                                            }
-                                                        }
-                                                    ],
-                                                    kind: "media",
-                                                    loc: null,
-                                                    type: "Condition"
-                                                },
-                                                loc: null,
-                                                mediaType: "screen",
-                                                modifier: null,
-                                                type: "MediaQuery"
-                                            }
-                                        ],
-                                        loc: null,
-                                        type: "MediaQueryList"
-                                    }
-                                ],
-                                loc: null,
-                                type: "AtrulePrelude"
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-        });
-        
-        describe('Validation', () => {
-            [
-                "@import 'tailwindcss';",
-                "@import url('test.css');",
-                "@import 'tailwindcss' prefix(tw);",
-                "@import 'tailwindcss' source('..');",
-                "@import 'tailwindcss' source(none);",
-                "@import 'tailwindcss' source(none) prefix(tw);",
-                '@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
-                '@import "./foo.css" layer;',
-                '@import "./foo.css" layer(utilities);',
-                '@import url("bluish.css") print, screen;',
-                '@import url("landscape.css") screen and (orientation: landscape);',
-            ].forEach((prelude) => {
-                it("should allow valid prelude", () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("import", tree.children[0].prelude);
-                    assert.equal(error, null);
-                });
-            });
+	createThemeFunctionTests(fork(tailwind4));
 
-            [
-                "@import 'foo' 'bar';",
-                "@import 'tailwindcss' print, screen prefix(tw);",
-                '@import url("landscape.css") screen and (orientation: landscape) layer(base);',
-                // todo: fail with these
-                // "@import 'tailwindcss' prefix(foo) prefix(bar);",
-                // "@import 'tailwindcss' prefix('foo');",
-                // "@import 'tailwindcss' prefix();",
-                // "@import 'tailwindcss' prefix;",
-                // "@import 'tailwindcss' source(foo);",
-                // "@import 'tailwindcss' source;",
-            ].forEach((prelude) => {
-                it("should fail with invalid prelude", () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("import", tree.children[0].prelude);
-                    assert.notEqual(error, null);
-                });
-            });
-        });
-    });
+	describe("@import", () => {
+		describe("Parsing", () => {
+			it("should parse @import", () => {
+				const tree = toPlainObject(parse("@import 'tailwindcss';"));
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss",
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-    describe("@config", () => {
-        it("should parse @config with a string value", () => {
-            const tree = toPlainObject(parse("@config 'tailwind.config.js';"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "config",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "String",
-                                    value: "tailwind.config.js",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: null,
-                        loc: null
-                    }
-                ]
-            });
-        });
-    });
+			it("should parse @import with prefix()", () => {
+				const tree = toPlainObject(
+					parse("@import 'tailwindcss' prefix(tw);"),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss",
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "prefix",
+										children: [
+											{
+												type: "Identifier",
+												name: "tw",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-    describe("@plugin", () => {
-        it("should parse @plugin with a string value", () => {
-            const tree = toPlainObject(parse("@plugin 'tailwindcss/typography';"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "plugin",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "String",
-                                    value: "tailwindcss/typography",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: null,
-                        loc: null
-                    }
-                ]
-            });
-        });
-    });
+			it("should parse @import with source()", () => {
+				const tree = toPlainObject(
+					parse("@import 'tailwindcss' source('..');"),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss",
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "source",
+										children: [
+											{
+												type: "String",
+												value: "..",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-    describe("@theme", () => {
-        it("should parse @theme with inline prelude", () => {
-            const tree = toPlainObject(parse("@theme inline { --color-primary: #ff0000; }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "theme",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Identifier",
-                                    name: "inline",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Declaration",
-                                    loc: null,
-                                    property: "--color-primary",
-                                    value: {
-                                        type: "Raw",
-                                        value: " #ff0000",
-                                        loc: null
-                                    },
-                                    important: false
-                                }
-                            ]
-                        },
-                        loc: null
-                    }
-                ]
-            });
-        });
+			it("should parse @import with source(none)", () => {
+				const tree = toPlainObject(
+					parse("@import 'tailwindcss' source(none);"),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss",
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "source",
+										children: [
+											{
+												type: "Identifier",
+												name: "none",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-        it("should parse @theme with static prelude", () => {
-            const tree = toPlainObject(parse("@theme static { --color-primary: #ff0000; }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "theme",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Identifier",
-                                    name: "static",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Declaration",
-                                    loc: null,
-                                    property: "--color-primary",
-                                    value: {
-                                        type: "Raw",
-                                        value: " #ff0000",
-                                        loc: null
-                                    },
-                                    important: false
-                                }
-                            ]
-                        },
-                        loc: null
-                    }
-                ]
-            });
-        });
+			it("should parse @import with source and prefix", () => {
+				const tree = toPlainObject(
+					parse("@import 'tailwindcss' source(none) prefix(tw);"),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss",
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "source",
+										children: [
+											{
+												type: "Identifier",
+												name: "none",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "prefix",
+										children: [
+											{
+												type: "Identifier",
+												name: "tw",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-        describe("Validation", () => {
-            [
-                "@theme { --color-primary: #ff0000; }",
-                "@theme inline { --color-primary: #ff0000; }",
-                "@theme static { --color-primary: #ff0000; }"
-            ].forEach((prelude) => {
-                it(`should allow valid prelude: ${prelude}`, () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("theme", tree.children[0].prelude);
-                    assert.equal(error, null);
-                });
-            });
+			it("should parse @import with source, prefix and layer", () => {
+				const tree = toPlainObject(
+					parse(
+						'@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
+					),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "tailwindcss/utilities.css",
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "source",
+										children: [
+											{
+												type: "Identifier",
+												name: "none",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "prefix",
+										children: [
+											{
+												type: "Identifier",
+												name: "tw",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+									{
+										type: "Function",
+										name: "layer",
+										children: [
+											{
+												type: "Layer",
+												name: "utilities",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-            [
-                "@theme colors { --color-primary: #ff0000; }",
-                "@theme inline static { --color-primary: #ff0000; }",
-                "@theme static inline { --color-primary: #ff0000; }"
-            ].forEach((prelude) => {
-                it(`should fail with invalid prelude: ${prelude}`, () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("theme", tree.children[0].prelude);
-                    assert.notEqual(error, null);
-                });
-            });
-        });
+			it("should parse @import with layer", () => {
+				const tree = toPlainObject(parse('@import "./foo.css" layer;'));
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								children: [
+									{
+										loc: null,
+										type: "String",
+										value: "./foo.css",
+									},
+									{
+										loc: null,
+										name: "layer",
+										type: "Identifier",
+									},
+								],
+								loc: null,
+								type: "AtrulePrelude",
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-        it("should parse @theme wildcard custom property reset", () => {
-            const tree = toPlainObject(parse("@theme { --color-*: initial; }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "theme",
-                        prelude: null,
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Declaration",
-                                    loc: null,
-                                    property: "--color-*",
-                                    value: {
-                                        type: "Raw",
-                                        value: " initial",
-                                        loc: null
-                                    },
-                                    important: false
-                                }
-                            ]
-                        },
-                        loc: null
-                    }
-                ]
-            });
-        });
-    });
+			it("should parse @import with layer()", () => {
+				const tree = toPlainObject(
+					parse('@import "./foo.css" layer(utilities);'),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								children: [
+									{
+										loc: null,
+										type: "String",
+										value: "./foo.css",
+									},
+									{
+										children: [
+											{
+												loc: null,
+												name: "utilities",
+												type: "Layer",
+											},
+										],
+										loc: null,
+										name: "layer",
+										type: "Function",
+									},
+								],
+								loc: null,
+								type: "AtrulePrelude",
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-    describe("@source", () => {
-        describe("Parsing", () => {
-            it("should parse @source", () => {
-                const tree = toPlainObject(parse("@source '../node_modules/@acmecorp/ui-lib';"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "source",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "String",
-                                        value: "../node_modules/@acmecorp/ui-lib",
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
+			it("should parse @import with media query list", () => {
+				const tree = toPlainObject(
+					parse('@import url("bluish.css") print, screen;'),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								children: [
+									{
+										loc: null,
+										type: "Url",
+										value: "bluish.css",
+									},
+									{
+										children: [
+											{
+												condition: null,
+												loc: null,
+												mediaType: "print",
+												modifier: null,
+												type: "MediaQuery",
+											},
+											{
+												condition: null,
+												loc: null,
+												mediaType: "screen",
+												modifier: null,
+												type: "MediaQuery",
+											},
+										],
+										loc: null,
+										type: "MediaQueryList",
+									},
+								],
+								loc: null,
+								type: "AtrulePrelude",
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-            it("should parse @source not", () => {
-                const tree = toPlainObject(parse('@source not "../src/components/legacy";'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "source",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        type: "Identifier",
-                                        name: "not",
-                                        loc: null
-                                    },
-                                    {
-                                        type: "String",
-                                        value: "../src/components/legacy",
-                                        loc: null
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
+			it("should parse @import with complex media query", () => {
+				const tree = toPlainObject(
+					parse(
+						'@import url("landscape.css") screen and (orientation: landscape);',
+					),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "import",
+							prelude: {
+								children: [
+									{
+										loc: null,
+										type: "Url",
+										value: "landscape.css",
+									},
+									{
+										children: [
+											{
+												condition: {
+													children: [
+														{
+															kind: "media",
+															loc: null,
+															name: "orientation",
+															type: "Feature",
+															value: {
+																loc: null,
+																name: "landscape",
+																type: "Identifier",
+															},
+														},
+													],
+													kind: "media",
+													loc: null,
+													type: "Condition",
+												},
+												loc: null,
+												mediaType: "screen",
+												modifier: null,
+												type: "MediaQuery",
+											},
+										],
+										loc: null,
+										type: "MediaQueryList",
+									},
+								],
+								loc: null,
+								type: "AtrulePrelude",
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
+		});
 
-            it("should parse @source inline()", () => {
-                const tree = toPlainObject(parse("@source inline('{hover:,}bg-red-{50,{100..900..100},950}');"));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "source",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        "children": [
-                                            {
-                                                "loc": null,
-                                                "type": "String",
-                                                "value": "{hover:,}bg-red-{50,{100..900..100},950}"
-                                            }
-                                        ],
-                                        "loc": null,
-                                        "name": "inline",
-                                        "type": "Function"
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
+		describe("Validation", () => {
+			[
+				"@import 'tailwindcss';",
+				"@import url('test.css');",
+				"@import 'tailwindcss' prefix(tw);",
+				"@import 'tailwindcss' source('..');",
+				"@import 'tailwindcss' source(none);",
+				"@import 'tailwindcss' source(none) prefix(tw);",
+				'@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
+				'@import "./foo.css" layer;',
+				'@import "./foo.css" layer(utilities);',
+				'@import url("bluish.css") print, screen;',
+				'@import url("landscape.css") screen and (orientation: landscape);',
+			].forEach(prelude => {
+				it("should allow valid prelude", () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"import",
+						tree.children[0].prelude,
+					);
+					assert.equal(error, null);
+				});
+			});
 
-            it("should parse @source not inline()", () => {
-                const tree = toPlainObject(parse('@source not inline("container");'));
-                assert.deepStrictEqual(tree, {
-                    type: "StyleSheet",
-                    loc: null,
-                    children: [
-                        {
-                            type: "Atrule",
-                            name: "source",
-                            prelude: {
-                                type: "AtrulePrelude",
-                                loc: null,
-                                children: [
-                                    {
-                                        "loc": null,
-                                        "name": "not",
-                                        "type": "Identifier"
-                                    },
-                                    {
-                                        "children": [
-                                            {
-                                                "loc": null,
-                                                "type": "String",
-                                                "value": "container"
-                                            }
-                                        ],
-                                        "loc": null,
-                                        "name": "inline",
-                                        "type": "Function"
-                                    }
-                                ]
-                            },
-                            block: null,
-                            loc: null
-                        }
-                    ]
-                });
-            });
-        });
+			[
+				"@import 'foo' 'bar';",
+				"@import 'tailwindcss' print, screen prefix(tw);",
+				'@import url("landscape.css") screen and (orientation: landscape) layer(base);',
+				// todo: fail with these
+				// "@import 'tailwindcss' prefix(foo) prefix(bar);",
+				// "@import 'tailwindcss' prefix('foo');",
+				// "@import 'tailwindcss' prefix();",
+				// "@import 'tailwindcss' prefix;",
+				// "@import 'tailwindcss' source(foo);",
+				// "@import 'tailwindcss' source;",
+			].forEach(prelude => {
+				it("should fail with invalid prelude", () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"import",
+						tree.children[0].prelude,
+					);
+					assert.notEqual(error, null);
+				});
+			});
+		});
+	});
 
-        describe('Validation', () => {
-            [
-                "@source '../foo';",
-                '@source not "./bar";',
-                "@source inline('container');",
-                "@source not inline('container');",
-            ].forEach((prelude) => {
-                it("should allow valid prelude", () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("source", tree.children[0].prelude);
-                    assert.equal(error, null);
-                });
-            });
+	describe("@config", () => {
+		it("should parse @config with a string value", () => {
+			const tree = toPlainObject(parse("@config 'tailwind.config.js';"));
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "config",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "String",
+									value: "tailwind.config.js",
+									loc: null,
+								},
+							],
+						},
+						block: null,
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-            [
-                "@source foo;",
-                "@source 10;",
-                "@source foo 'bar';",
-                "@source foo inline('bar');",
-                "@source not inline('bar') 'baz';",
-                "@source foo('bar');",
-            ].forEach((prelude) => {
-                it("should fail with invalid prelude", () => {
-                    const tree = toPlainObject(parse(prelude));
-                    const { error } = lexer.matchAtrulePrelude("source", tree.children[0].prelude);
-                    assert.notEqual(error, null);
-                });
-          });
-      });
-    });
+	describe("@plugin", () => {
+		it("should parse @plugin with a string value", () => {
+			const tree = toPlainObject(
+				parse("@plugin 'tailwindcss/typography';"),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "plugin",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "String",
+									value: "tailwindcss/typography",
+									loc: null,
+								},
+							],
+						},
+						block: null,
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-    describe("@variant", () => {
-        it("should parse @variant with a valid prelude", () => {
-            const tree = toPlainObject(parse("@variant hover { .example { color: blue; } }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "variant",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Identifier",
-                                    name: "hover",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Rule",
-                                    loc: null,
-                                    prelude: {
-                                        type: "SelectorList",
-                                        loc: null,
-                                        children: [
-                                            {
-                                                type: "Selector",
-                                                loc: null,
-                                                children: [
-                                                    {
-                                                        type: "ClassSelector",
-                                                        name: "example",
-                                                        loc: null
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    block: {
-                                        type: "Block",
-                                        loc: null,
-                                        children: [
-                                            {
-                                                type: "Declaration",
-                                                loc: null,
-                                                property: "color",
-                                                value: {
-                                                    type: "Value",
-                                                    children: [
-                                                        {
-                                                            type: "Identifier",
-                                                            name: "blue",
-                                                            loc: null
-                                                        }
-                                                    ],
-                                                    loc: null
-                                                },
-                                                important: false
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        },
-                        loc: null
-                    }
-                ]
-            });
-        });
-    });
+	describe("@theme", () => {
+		it("should parse @theme with inline prelude", () => {
+			const tree = toPlainObject(
+				parse("@theme inline { --color-primary: #ff0000; }"),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "theme",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "Identifier",
+									name: "inline",
+									loc: null,
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Declaration",
+									loc: null,
+									property: "--color-primary",
+									value: {
+										type: "Raw",
+										value: " #ff0000",
+										loc: null,
+									},
+									important: false,
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
 
-    describe("@custom-variant", () => {
-        it("should parse @custom-variant with an inline selector list", () => {
-            const tree = toPlainObject(parse("@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));"));
-            const atrule = tree.children[0];
+		it("should parse @theme with static prelude", () => {
+			const tree = toPlainObject(
+				parse("@theme static { --color-primary: #ff0000; }"),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "theme",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "Identifier",
+									name: "static",
+									loc: null,
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Declaration",
+									loc: null,
+									property: "--color-primary",
+									value: {
+										type: "Raw",
+										value: " #ff0000",
+										loc: null,
+									},
+									important: false,
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
 
-            assert.equal(atrule.type, "Atrule");
-            assert.equal(atrule.name, "custom-variant");
-            assert.equal(atrule.block, null);
-            assert.equal(atrule.prelude.type, "AtrulePrelude");
-            assert.equal(atrule.prelude.children.length, 2);
-            assert.equal(
-                atrule.prelude.children[1].value,
-                "(&:where([data-theme=dark], [data-theme=dark] *))",
-            );
-        });
+		describe("Validation", () => {
+			[
+				"@theme { --color-primary: #ff0000; }",
+				"@theme inline { --color-primary: #ff0000; }",
+				"@theme static { --color-primary: #ff0000; }",
+			].forEach(prelude => {
+				it(`should allow valid prelude: ${prelude}`, () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"theme",
+						tree.children[0].prelude,
+					);
+					assert.equal(error, null);
+				});
+			});
 
-        it("should parse @custom-variant with a block body using @slot", () => {
-            const tree = toPlainObject(parse('@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }'));
-            const atrule = tree.children[0];
+			[
+				"@theme colors { --color-primary: #ff0000; }",
+				"@theme inline static { --color-primary: #ff0000; }",
+				"@theme static inline { --color-primary: #ff0000; }",
+			].forEach(prelude => {
+				it(`should fail with invalid prelude: ${prelude}`, () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"theme",
+						tree.children[0].prelude,
+					);
+					assert.notEqual(error, null);
+				});
+			});
+		});
 
-            assert.equal(atrule.type, "Atrule");
-            assert.equal(atrule.name, "custom-variant");
-            assert.equal(atrule.prelude.type, "AtrulePrelude");
-            assert.equal(atrule.prelude.children[0].name, "theme-midnight");
-            assert.equal(atrule.block.children[0].type, "Rule");
-            assert.equal(atrule.block.children[0].block.children[0].name, "slot");
-        });
+		it("should parse @theme wildcard custom property reset", () => {
+			const tree = toPlainObject(parse("@theme { --color-*: initial; }"));
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "theme",
+						prelude: null,
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Declaration",
+									loc: null,
+									property: "--color-*",
+									value: {
+										type: "Raw",
+										value: " initial",
+										loc: null,
+									},
+									important: false,
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-        it("should parse @custom-variant with a single inline selector", () => {
-            const tree = toPlainObject(parse('@custom-variant theme-midnight (&:where([data-theme="midnight"] *));'));
-            const atrule = tree.children[0];
+	describe("@source", () => {
+		describe("Parsing", () => {
+			it("should parse @source", () => {
+				const tree = toPlainObject(
+					parse("@source '../node_modules/@acmecorp/ui-lib';"),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "source",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "String",
+										value: "../node_modules/@acmecorp/ui-lib",
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-            assert.equal(atrule.type, "Atrule");
-            assert.equal(atrule.name, "custom-variant");
-            assert.equal(atrule.block, null);
-            assert.equal(atrule.prelude.type, "AtrulePrelude");
-            assert.equal(atrule.prelude.children.length, 2);
-            assert.equal(atrule.prelude.children[1].value, '(&:where([data-theme="midnight"] *))');
-        });
+			it("should parse @source not", () => {
+				const tree = toPlainObject(
+					parse('@source not "../src/components/legacy";'),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "source",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										type: "Identifier",
+										name: "not",
+										loc: null,
+									},
+									{
+										type: "String",
+										value: "../src/components/legacy",
+										loc: null,
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-        it("should parse @custom-variant with nested at-rules in a block body", () => {
-            const tree = toPlainObject(parse("@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }"));
-            const atrule = tree.children[0];
+			it("should parse @source inline()", () => {
+				const tree = toPlainObject(
+					parse(
+						"@source inline('{hover:,}bg-red-{50,{100..900..100},950}');",
+					),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "source",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										children: [
+											{
+												loc: null,
+												type: "String",
+												value: "{hover:,}bg-red-{50,{100..900..100},950}",
+											},
+										],
+										loc: null,
+										name: "inline",
+										type: "Function",
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
 
-            assert.equal(atrule.type, "Atrule");
-            assert.equal(atrule.name, "custom-variant");
-            assert.equal(atrule.prelude.type, "AtrulePrelude");
-            assert.equal(atrule.prelude.children[0].name, "any-hover");
-            assert.equal(atrule.block.children[0].name, "media");
-            assert.equal(atrule.block.children[0].block.children[0].type, "Rule");
-        });
+			it("should parse @source not inline()", () => {
+				const tree = toPlainObject(
+					parse('@source not inline("container");'),
+				);
+				assert.deepStrictEqual(tree, {
+					type: "StyleSheet",
+					loc: null,
+					children: [
+						{
+							type: "Atrule",
+							name: "source",
+							prelude: {
+								type: "AtrulePrelude",
+								loc: null,
+								children: [
+									{
+										loc: null,
+										name: "not",
+										type: "Identifier",
+									},
+									{
+										children: [
+											{
+												loc: null,
+												type: "String",
+												value: "container",
+											},
+										],
+										loc: null,
+										name: "inline",
+										type: "Function",
+									},
+								],
+							},
+							block: null,
+							loc: null,
+						},
+					],
+				});
+			});
+		});
 
-        describe("Validation", () => {
-            [
-                "@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
-                '@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
-                '@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
-                "@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
-            ].forEach((cssRule) => {
-                it(`should allow valid prelude: ${cssRule}`, () => {
-                    const tree = toPlainObject(parse(cssRule));
-                    const { error } = lexer.matchAtrulePrelude("custom-variant", tree.children[0].prelude);
-                    assert.equal(error, null);
-                });
-            });
-        });
-    });
+		describe("Validation", () => {
+			[
+				"@source '../foo';",
+				'@source not "./bar";',
+				"@source inline('container');",
+				"@source not inline('container');",
+			].forEach(prelude => {
+				it("should allow valid prelude", () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"source",
+						tree.children[0].prelude,
+					);
+					assert.equal(error, null);
+				});
+			});
 
-    describe("@apply", () => {
-        it("should parse @apply with valid classes", () => {
-            const tree = toPlainObject(parse(".example { @apply bg-red-500 text-white focus:ring-3 grid-cols-[200px_auto]; }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Rule",
-                        loc: null,
-                        prelude: {
-                            type: "SelectorList",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Selector",
-                                    loc: null,
-                                    children: [
-                                        {
-                                            type: "ClassSelector",
-                                            name: "example",
-                                            loc: null
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Atrule",
-                                    name: "apply",
-                                    prelude: {
-                                        type: "AtrulePrelude",
-                                        loc: null,
-                                        children: [
-                                            {
-                                                type: "Identifier",
-                                                name: "bg-red-500",
-                                                loc: null
-                                            },
-                                            {
-                                                type: "Identifier",
-                                                name: "text-white",
-                                                loc: null
-                                            },
-                                            {
-                                                type: "TailwindUtilityClass",
-                                                loc: null,
-                                                variant: {
-                                                    type: "Identifier",
-                                                    name: "focus",
-                                                    loc: null
-                                                },
-                                                name: {
-                                                    type: "Identifier",
-                                                    name: "ring-3",
-                                                    loc: null
-                                                }
-                                            },
-                                            {
-                                                type: "TailwindUtilityClass",
-                                                loc: null,
-                                                variant: null,
-                                                name: {
-                                                    type: "Identifier",
-                                                    name: "grid-cols-[200px_auto]",
-                                                    loc: null
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    block: null,
-                                    loc: null
-                                }
-                            ]
-                        }
-                    }
-                ]
-            });
-        });
+			[
+				"@source foo;",
+				"@source 10;",
+				"@source foo 'bar';",
+				"@source foo inline('bar');",
+				"@source not inline('bar') 'baz';",
+				"@source foo('bar');",
+			].forEach(prelude => {
+				it("should fail with invalid prelude", () => {
+					const tree = toPlainObject(parse(prelude));
+					const { error } = lexer.matchAtrulePrelude(
+						"source",
+						tree.children[0].prelude,
+					);
+					assert.notEqual(error, null);
+				});
+			});
+		});
+	});
 
-        it("should parse @apply with responsive condition variants", () => {
-            assert.doesNotThrow(() => {
-                parse(".example { @apply sm:grid; }");
-            });
-        });
+	describe("@utility", () => {
+		it("should parse @utility with a valid prelude", () => {
+			const tree = toPlainObject(
+				parse(
+					"@utility font-mono { font-feature-numeric: tabular-nums; }",
+				),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "utility",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "Identifier",
+									name: "font-mono",
+									loc: null,
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Declaration",
+									loc: null,
+									property: "font-feature-numeric",
+									value: {
+										type: "Value",
+										children: [
+											{
+												type: "Identifier",
+												name: "tabular-nums",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+									important: false,
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-        it("should parse @apply with slash notation for opacity modifiers", () => {
-            const testCases = [
-                "a { @apply outline-ring/50; }",
-                "a { @apply bg-blue-500/30; }",
-                "a { @apply border-gray-200/50; }",
-            ];
+	describe("@variant", () => {
+		it("should parse @variant with a valid prelude", () => {
+			const tree = toPlainObject(
+				parse("@variant hover { .example { color: blue; } }"),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "variant",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "Identifier",
+									name: "hover",
+									loc: null,
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Rule",
+									loc: null,
+									prelude: {
+										type: "SelectorList",
+										loc: null,
+										children: [
+											{
+												type: "Selector",
+												loc: null,
+												children: [
+													{
+														type: "ClassSelector",
+														name: "example",
+														loc: null,
+													},
+												],
+											},
+										],
+									},
+									block: {
+										type: "Block",
+										loc: null,
+										children: [
+											{
+												type: "Declaration",
+												loc: null,
+												property: "color",
+												value: {
+													type: "Value",
+													children: [
+														{
+															type: "Identifier",
+															name: "blue",
+															loc: null,
+														},
+													],
+													loc: null,
+												},
+												important: false,
+											},
+										],
+									},
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-            testCases.forEach((testCase) => {
-                assert.doesNotThrow(() => {
-                    const result = parse(testCase);
-                    assert.ok(result, `Should parse: ${testCase}`);
-                }, `Should not throw parsing errors for: ${testCase}`);
-            });
-        });
-        
-        it("should parse @apply with variants and slash notation", () => {
-            const testCases = [
-                "a { @apply hover:bg-blue-500/50; }",
-                "a { @apply focus:outline-ring/30; }",
-                "a { @apply active:border-red-500/25; }",
-            ];
-            
-            testCases.forEach((testCase) => {
-                assert.doesNotThrow(() => {
-                    const result = parse(testCase);
-                    assert.ok(result, `Should parse: ${testCase}`);
-                }, `Should not throw parsing errors for: ${testCase}`);
-            });
-        });
+	describe("@custom-variant", () => {
+		it("should parse @custom-variant with an inline selector list", () => {
+			const tree = toPlainObject(
+				parse(
+					"@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
+				),
+			);
+			const atrule = tree.children[0];
 
-        it("should parse @apply with square bracket arbitrary values", () => {
-            const testCases = [
-                "a { @apply grid-cols-[200px_auto]; }",
-                "a { @apply hover:grid-cols-[200px_auto]; }",
-            ];
-            
-            testCases.forEach((testCase) => {
-                assert.doesNotThrow(() => {
-                    const result = parse(testCase);
-                    assert.ok(result, `Should parse: ${testCase}`);
-                }, `Should not throw parsing errors for: ${testCase}`);
-            });
-        });
-        
-        it("should parse the original issue CSS without errors", () => {
-            const originalCSS = `
+			assert.equal(atrule.type, "Atrule");
+			assert.equal(atrule.name, "custom-variant");
+			assert.equal(atrule.block, null);
+			assert.equal(atrule.prelude.type, "AtrulePrelude");
+			assert.equal(atrule.prelude.children.length, 2);
+			assert.equal(
+				atrule.prelude.children[1].value,
+				"(&:where([data-theme=dark], [data-theme=dark] *))",
+			);
+		});
+
+		it("should parse @custom-variant with a block body using @slot", () => {
+			const tree = toPlainObject(
+				parse(
+					'@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
+				),
+			);
+			const atrule = tree.children[0];
+
+			assert.equal(atrule.type, "Atrule");
+			assert.equal(atrule.name, "custom-variant");
+			assert.equal(atrule.prelude.type, "AtrulePrelude");
+			assert.equal(atrule.prelude.children[0].name, "theme-midnight");
+			assert.equal(atrule.block.children[0].type, "Rule");
+			assert.equal(
+				atrule.block.children[0].block.children[0].name,
+				"slot",
+			);
+		});
+
+		it("should parse @custom-variant with a single inline selector", () => {
+			const tree = toPlainObject(
+				parse(
+					'@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
+				),
+			);
+			const atrule = tree.children[0];
+
+			assert.equal(atrule.type, "Atrule");
+			assert.equal(atrule.name, "custom-variant");
+			assert.equal(atrule.block, null);
+			assert.equal(atrule.prelude.type, "AtrulePrelude");
+			assert.equal(atrule.prelude.children.length, 2);
+			assert.equal(
+				atrule.prelude.children[1].value,
+				'(&:where([data-theme="midnight"] *))',
+			);
+		});
+
+		it("should parse @custom-variant with nested at-rules in a block body", () => {
+			const tree = toPlainObject(
+				parse(
+					"@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
+				),
+			);
+			const atrule = tree.children[0];
+
+			assert.equal(atrule.type, "Atrule");
+			assert.equal(atrule.name, "custom-variant");
+			assert.equal(atrule.prelude.type, "AtrulePrelude");
+			assert.equal(atrule.prelude.children[0].name, "any-hover");
+			assert.equal(atrule.block.children[0].name, "media");
+			assert.equal(
+				atrule.block.children[0].block.children[0].type,
+				"Rule",
+			);
+		});
+
+		describe("Validation", () => {
+			[
+				"@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
+				'@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
+				'@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
+				"@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
+			].forEach(cssRule => {
+				it(`should allow valid prelude: ${cssRule}`, () => {
+					const tree = toPlainObject(parse(cssRule));
+					const { error } = lexer.matchAtrulePrelude(
+						"custom-variant",
+						tree.children[0].prelude,
+					);
+					assert.equal(error, null);
+				});
+			});
+		});
+	});
+
+	describe("@apply", () => {
+		it("should parse @apply with valid classes", () => {
+			const tree = toPlainObject(
+				parse(
+					".example { @apply bg-red-500 text-white focus:ring-3 grid-cols-[200px_auto]; }",
+				),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Rule",
+						loc: null,
+						prelude: {
+							type: "SelectorList",
+							loc: null,
+							children: [
+								{
+									type: "Selector",
+									loc: null,
+									children: [
+										{
+											type: "ClassSelector",
+											name: "example",
+											loc: null,
+										},
+									],
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Atrule",
+									name: "apply",
+									prelude: {
+										type: "AtrulePrelude",
+										loc: null,
+										children: [
+											{
+												type: "Identifier",
+												name: "bg-red-500",
+												loc: null,
+											},
+											{
+												type: "Identifier",
+												name: "text-white",
+												loc: null,
+											},
+											{
+												type: "TailwindUtilityClass",
+												loc: null,
+												variant: {
+													type: "Identifier",
+													name: "focus",
+													loc: null,
+												},
+												name: {
+													type: "Identifier",
+													name: "ring-3",
+													loc: null,
+												},
+											},
+											{
+												type: "TailwindUtilityClass",
+												loc: null,
+												variant: null,
+												name: {
+													type: "Identifier",
+													name: "grid-cols-[200px_auto]",
+													loc: null,
+												},
+											},
+										],
+									},
+									block: null,
+									loc: null,
+								},
+							],
+						},
+					},
+				],
+			});
+		});
+
+		it("should parse @apply with responsive condition variants", () => {
+			assert.doesNotThrow(() => {
+				parse(".example { @apply sm:grid; }");
+			});
+		});
+
+		it("should parse @apply with slash notation for opacity modifiers", () => {
+			const testCases = [
+				"a { @apply outline-ring/50; }",
+				"a { @apply bg-blue-500/30; }",
+				"a { @apply border-gray-200/50; }",
+			];
+
+			testCases.forEach(testCase => {
+				assert.doesNotThrow(() => {
+					const result = parse(testCase);
+					assert.ok(result, `Should parse: ${testCase}`);
+				}, `Should not throw parsing errors for: ${testCase}`);
+			});
+		});
+
+		it("should parse @apply with variants and slash notation", () => {
+			const testCases = [
+				"a { @apply hover:bg-blue-500/50; }",
+				"a { @apply focus:outline-ring/30; }",
+				"a { @apply active:border-red-500/25; }",
+			];
+
+			testCases.forEach(testCase => {
+				assert.doesNotThrow(() => {
+					const result = parse(testCase);
+					assert.ok(result, `Should parse: ${testCase}`);
+				}, `Should not throw parsing errors for: ${testCase}`);
+			});
+		});
+
+		it("should parse @apply with square bracket arbitrary values", () => {
+			const testCases = [
+				"a { @apply grid-cols-[200px_auto]; }",
+				"a { @apply hover:grid-cols-[200px_auto]; }",
+			];
+
+			testCases.forEach(testCase => {
+				assert.doesNotThrow(() => {
+					const result = parse(testCase);
+					assert.ok(result, `Should parse: ${testCase}`);
+				}, `Should not throw parsing errors for: ${testCase}`);
+			});
+		});
+
+		it("should parse the original issue CSS without errors", () => {
+			const originalCSS = `
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -1176,126 +1318,144 @@ describe("Tailwind 4", function () {
   }
 }
             `;
-            
-            // The original issue was that this would throw:
-            // "Parsing error: Semicolon or block is expected"
-            // Now it should parse successfully
-            assert.doesNotThrow(() => {
-                const result = parse(originalCSS);
-                assert.ok(result, "Should return a valid AST");
-            }, "Should not throw parsing errors");
-        });
-    });
 
-    describe("@reference", () => {
-        it("should parse @reference with a valid prelude", () => {
-            const tree = toPlainObject(parse("@reference colors { primary: #00ff00; }"));
-            assert.deepStrictEqual(tree, {
-                type: "StyleSheet",
-                loc: null,
-                children: [
-                    {
-                        type: "Atrule",
-                        name: "reference",
-                        prelude: {
-                            type: "AtrulePrelude",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Identifier",
-                                    name: "colors",
-                                    loc: null
-                                }
-                            ]
-                        },
-                        block: {
-                            type: "Block",
-                            loc: null,
-                            children: [
-                                {
-                                    type: "Declaration",
-                                    loc: null,
-                                    property: "primary",
-                                    value: {
-                                        type: "Value",
-                                        children: [
-                                            {
-                                                type: "Hash",
-                                                value: "00ff00",
-                                                loc: null
-                                            }
-                                        ],
-                                        loc: null
-                                    },
-                                    important: false
-                                }
-                            ]
-                        },
-                        loc: null
-                    }
-                ]
-            });
-        });
-    });
-    
-    describe("Validation", () => {
-        describe("Type Validation", () => {
-            [
-                "--alpha(#000 / 50%)",
-                "--alpha(white / 70%)",
-                "--alpha(rgba(0, 0, 0, 0.5) / 1%)",
-            ].forEach((value) => {
-                it(`should validate type <tw-alpha> with ${value}`, () => {
-                    const tree = parse(value, { context: 'value' });
-                    assert.strictEqual(lexer.matchType("tw-alpha", tree).error, null);
-                });
+			// The original issue was that this would throw:
+			// "Parsing error: Semicolon or block is expected"
+			// Now it should parse successfully
+			assert.doesNotThrow(() => {
+				const result = parse(originalCSS);
+				assert.ok(result, "Should return a valid AST");
+			}, "Should not throw parsing errors");
+		});
+	});
 
-                it(`should validate type <tw-any-color> with ${value}`, () => {
-                    const tree = parse(value, { context: 'value' });
-                    assert.strictEqual(lexer.matchType("tw-any-color", tree).error, null);
-                });
-            });
-            
-            [
-                "--spacing(4)",
-                "--spacing(12)",
-                "--spacing(0.5)",
-            ].forEach((value) => {
-                it(`should validate type <tw-spacing> with ${value}`, () => {
-                    const tree = parse(value, { context: 'value' });
-                    assert.strictEqual(lexer.matchType("tw-spacing", tree).error, null);
-                });
+	describe("@reference", () => {
+		it("should parse @reference with a valid prelude", () => {
+			const tree = toPlainObject(
+				parse("@reference colors { primary: #00ff00; }"),
+			);
+			assert.deepStrictEqual(tree, {
+				type: "StyleSheet",
+				loc: null,
+				children: [
+					{
+						type: "Atrule",
+						name: "reference",
+						prelude: {
+							type: "AtrulePrelude",
+							loc: null,
+							children: [
+								{
+									type: "Identifier",
+									name: "colors",
+									loc: null,
+								},
+							],
+						},
+						block: {
+							type: "Block",
+							loc: null,
+							children: [
+								{
+									type: "Declaration",
+									loc: null,
+									property: "primary",
+									value: {
+										type: "Value",
+										children: [
+											{
+												type: "Hash",
+												value: "00ff00",
+												loc: null,
+											},
+										],
+										loc: null,
+									},
+									important: false,
+								},
+							],
+						},
+						loc: null,
+					},
+				],
+			});
+		});
+	});
 
-                it(`should validate type <tw-any-spacing> with ${value}`, () => {
-                    const tree = parse(value, { context: 'value' });
-                    assert.strictEqual(lexer.matchType("tw-any-spacing", tree).error, null);
-                });
-            });
-        });
-        
-        describe("Property Validation", () => {
-            
-            it("should validate margin: --spacing(4)", () => {
-                const tree = toPlainObject(parse("a { margin: --spacing(4); }"));
-                const { error } = lexer.matchDeclaration(tree.children[0].block.children[0]);
-                assert.strictEqual(error, null);
-            });
-            
-            it("should validate color: --alpha(#000 / 50%)", () => {
-                const tree = toPlainObject(parse("a { color: --alpha(#000 / 50%); }"));
-                const { error } = lexer.matchDeclaration(tree.children[0].block.children[0]);
-                assert.strictEqual(error, null);
-            });
-            
-        });
-    });
+	describe("Validation", () => {
+		describe("Type Validation", () => {
+			[
+				"--alpha(#000 / 50%)",
+				"--alpha(white / 70%)",
+				"--alpha(rgba(0, 0, 0, 0.5) / 1%)",
+			].forEach(value => {
+				it(`should validate type <tw-alpha> with ${value}`, () => {
+					const tree = parse(value, { context: "value" });
+					assert.strictEqual(
+						lexer.matchType("tw-alpha", tree).error,
+						null,
+					);
+				});
 
-    describe("Canonical Tailwind 4 File", () => {
-        it("should parse a canonical Tailwind 4 file", async () => {
-            const file = await fs.readFile(filename, "utf8");
-            const tree = toPlainObject(parse(file));
-            
-            assert.strictEqual(tree.type, "StyleSheet");
-        });
-    });
+				it(`should validate type <tw-any-color> with ${value}`, () => {
+					const tree = parse(value, { context: "value" });
+					assert.strictEqual(
+						lexer.matchType("tw-any-color", tree).error,
+						null,
+					);
+				});
+			});
+
+			["--spacing(4)", "--spacing(12)", "--spacing(0.5)"].forEach(
+				value => {
+					it(`should validate type <tw-spacing> with ${value}`, () => {
+						const tree = parse(value, { context: "value" });
+						assert.strictEqual(
+							lexer.matchType("tw-spacing", tree).error,
+							null,
+						);
+					});
+
+					it(`should validate type <tw-any-spacing> with ${value}`, () => {
+						const tree = parse(value, { context: "value" });
+						assert.strictEqual(
+							lexer.matchType("tw-any-spacing", tree).error,
+							null,
+						);
+					});
+				},
+			);
+		});
+
+		describe("Property Validation", () => {
+			it("should validate margin: --spacing(4)", () => {
+				const tree = toPlainObject(
+					parse("a { margin: --spacing(4); }"),
+				);
+				const { error } = lexer.matchDeclaration(
+					tree.children[0].block.children[0],
+				);
+				assert.strictEqual(error, null);
+			});
+
+			it("should validate color: --alpha(#000 / 50%)", () => {
+				const tree = toPlainObject(
+					parse("a { color: --alpha(#000 / 50%); }"),
+				);
+				const { error } = lexer.matchDeclaration(
+					tree.children[0].block.children[0],
+				);
+				assert.strictEqual(error, null);
+			});
+		});
+	});
+
+	describe("Canonical Tailwind 4 File", () => {
+		it("should parse a canonical Tailwind 4 file", async () => {
+			const file = await fs.readFile(filename, "utf8");
+			const tree = toPlainObject(parse(file));
+
+			assert.strictEqual(tree.type, "StyleSheet");
+		});
+	});
 });

--- a/tests/tailwind4.test.js
+++ b/tests/tailwind4.test.js
@@ -24,1291 +24,1204 @@ const filename = "./tests/fixtures/tailwind4.css";
 //-----------------------------------------------------------------------------
 
 describe("Tailwind 4", function () {
-	let parse, toPlainObject, lexer;
-	beforeEach(() => {
-		({ parse, toPlainObject, lexer } = fork(tailwind4));
-	});
+    
+    let parse, toPlainObject, lexer;
+    beforeEach(() => {
+        ({ parse, toPlainObject, lexer } = fork(tailwind4));
+    });
 
-	it("tests that tailwind4 is a valid SyntaxExtension", () => {
-		parse("a { color: var(--foo); }");
-	});
+    it("tests that tailwind4 is a valid SyntaxExtension", () => {
+        parse("a { color: var(--foo); }");
+    });
+    
+    createThemeFunctionTests(fork(tailwind4));
 
-	createThemeFunctionTests(fork(tailwind4));
+    describe("@import", () => {
+        describe("Parsing", () => {
+            it("should parse @import", () => {
+                const tree = toPlainObject(parse("@import 'tailwindcss';"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss",
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with prefix()", () => {
+                const tree = toPlainObject(parse("@import 'tailwindcss' prefix(tw);"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "prefix",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "tw",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with source()", () => {
+                const tree = toPlainObject(parse("@import 'tailwindcss' source('..');"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "source",
+                                        children: [
+                                            {
+                                                type: "String",
+                                                value: "..",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with source(none)", () => {
+                const tree = toPlainObject(parse("@import 'tailwindcss' source(none);"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "source",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "none",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with source and prefix", () => {
+                const tree = toPlainObject(parse("@import 'tailwindcss' source(none) prefix(tw);"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "source",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "none",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "prefix",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "tw",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with source, prefix and layer", () => {
+                const tree = toPlainObject(parse('@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "tailwindcss/utilities.css",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "source",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "none",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "prefix",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "tw",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    },
+                                    {
+                                        type: "Function",
+                                        name: "layer",
+                                        children: [
+                                            {
+                                                type: "Layer",
+                                                name: "utilities",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with layer", () => {
+                const tree = toPlainObject(parse('@import "./foo.css" layer;'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                children: [
+                                    {
+                                        loc: null,
+                                        type: "String",
+                                        value: "./foo.css"
+                                    },
+                                    {
+                                        loc: null,
+                                        name: "layer",
+                                        type: "Identifier"
+                                    }
+                                ],
+                                loc: null,
+                                type: "AtrulePrelude"
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with layer()", () => {
+                const tree = toPlainObject(parse('@import "./foo.css" layer(utilities);'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                children: [
+                                    {
+                                        loc: null,
+                                        type: "String",
+                                        value: "./foo.css"
+                                    },
+                                    {
+                                        children: [
+                                            {
+                                                loc: null,
+                                                name: "utilities",
+                                                type: "Layer"
+                                            }
+                                        ],
+                                        loc: null,
+                                        name: "layer",
+                                        type: "Function"
+                                    }
+                                ],
+                                loc: null,
+                                type: "AtrulePrelude"
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with media query list", () => {
+                const tree = toPlainObject(parse('@import url("bluish.css") print, screen;'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                children: [
+                                    {
+                                        loc: null,
+                                        type: "Url",
+                                        value: "bluish.css"
+                                    },
+                                    {
+                                        children: [
+                                            {
+                                                condition: null,
+                                                loc: null,
+                                                mediaType: "print",
+                                                modifier: null,
+                                                type: "MediaQuery"
+                                            },
+                                            {
+                                                condition: null,
+                                                loc: null,
+                                                mediaType: "screen",
+                                                modifier: null,
+                                                type: "MediaQuery"
+                                            }
+                                        ],
+                                        loc: null,
+                                        type: "MediaQueryList"
+                                    }
+                                ],
+                                loc: null,
+                                type: "AtrulePrelude"
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+    
+            it("should parse @import with complex media query", () => {
+                const tree = toPlainObject(parse('@import url("landscape.css") screen and (orientation: landscape);'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "import",
+                            prelude: {
+                                children: [
+                                    {
+                                        loc: null,
+                                        type: "Url",
+                                        value: "landscape.css"
+                                    },
+                                    {
+                                        children: [
+                                            {
+                                                condition: {
+                                                    children: [
+                                                        {
+                                                            kind: "media",
+                                                            loc: null,
+                                                            name: "orientation",
+                                                            type: "Feature",
+                                                            value: {
+                                                                loc: null,
+                                                                name: "landscape",
+                                                                type: "Identifier"
+                                                            }
+                                                        }
+                                                    ],
+                                                    kind: "media",
+                                                    loc: null,
+                                                    type: "Condition"
+                                                },
+                                                loc: null,
+                                                mediaType: "screen",
+                                                modifier: null,
+                                                type: "MediaQuery"
+                                            }
+                                        ],
+                                        loc: null,
+                                        type: "MediaQueryList"
+                                    }
+                                ],
+                                loc: null,
+                                type: "AtrulePrelude"
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+        });
+        
+        describe('Validation', () => {
+            [
+                "@import 'tailwindcss';",
+                "@import url('test.css');",
+                "@import 'tailwindcss' prefix(tw);",
+                "@import 'tailwindcss' source('..');",
+                "@import 'tailwindcss' source(none);",
+                "@import 'tailwindcss' source(none) prefix(tw);",
+                '@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
+                '@import "./foo.css" layer;',
+                '@import "./foo.css" layer(utilities);',
+                '@import url("bluish.css") print, screen;',
+                '@import url("landscape.css") screen and (orientation: landscape);',
+            ].forEach((prelude) => {
+                it("should allow valid prelude", () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("import", tree.children[0].prelude);
+                    assert.equal(error, null);
+                });
+            });
 
-	describe("@import", () => {
-		describe("Parsing", () => {
-			it("should parse @import", () => {
-				const tree = toPlainObject(parse("@import 'tailwindcss';"));
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss",
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+            [
+                "@import 'foo' 'bar';",
+                "@import 'tailwindcss' print, screen prefix(tw);",
+                '@import url("landscape.css") screen and (orientation: landscape) layer(base);',
+                // todo: fail with these
+                // "@import 'tailwindcss' prefix(foo) prefix(bar);",
+                // "@import 'tailwindcss' prefix('foo');",
+                // "@import 'tailwindcss' prefix();",
+                // "@import 'tailwindcss' prefix;",
+                // "@import 'tailwindcss' source(foo);",
+                // "@import 'tailwindcss' source;",
+            ].forEach((prelude) => {
+                it("should fail with invalid prelude", () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("import", tree.children[0].prelude);
+                    assert.notEqual(error, null);
+                });
+            });
+        });
+    });
 
-			it("should parse @import with prefix()", () => {
-				const tree = toPlainObject(
-					parse("@import 'tailwindcss' prefix(tw);"),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss",
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "prefix",
-										children: [
-											{
-												type: "Identifier",
-												name: "tw",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+    describe("@config", () => {
+        it("should parse @config with a string value", () => {
+            const tree = toPlainObject(parse("@config 'tailwind.config.js';"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "config",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "String",
+                                    value: "tailwind.config.js",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: null,
+                        loc: null
+                    }
+                ]
+            });
+        });
+    });
 
-			it("should parse @import with source()", () => {
-				const tree = toPlainObject(
-					parse("@import 'tailwindcss' source('..');"),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss",
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "source",
-										children: [
-											{
-												type: "String",
-												value: "..",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+    describe("@plugin", () => {
+        it("should parse @plugin with a string value", () => {
+            const tree = toPlainObject(parse("@plugin 'tailwindcss/typography';"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "plugin",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "String",
+                                    value: "tailwindcss/typography",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: null,
+                        loc: null
+                    }
+                ]
+            });
+        });
+    });
 
-			it("should parse @import with source(none)", () => {
-				const tree = toPlainObject(
-					parse("@import 'tailwindcss' source(none);"),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss",
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "source",
-										children: [
-											{
-												type: "Identifier",
-												name: "none",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+    describe("@theme", () => {
+        it("should parse @theme with inline prelude", () => {
+            const tree = toPlainObject(parse("@theme inline { --color-primary: #ff0000; }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "theme",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Identifier",
+                                    name: "inline",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Declaration",
+                                    loc: null,
+                                    property: "--color-primary",
+                                    value: {
+                                        type: "Raw",
+                                        value: " #ff0000",
+                                        loc: null
+                                    },
+                                    important: false
+                                }
+                            ]
+                        },
+                        loc: null
+                    }
+                ]
+            });
+        });
 
-			it("should parse @import with source and prefix", () => {
-				const tree = toPlainObject(
-					parse("@import 'tailwindcss' source(none) prefix(tw);"),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss",
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "source",
-										children: [
-											{
-												type: "Identifier",
-												name: "none",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "prefix",
-										children: [
-											{
-												type: "Identifier",
-												name: "tw",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+        it("should parse @theme with static prelude", () => {
+            const tree = toPlainObject(parse("@theme static { --color-primary: #ff0000; }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "theme",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Identifier",
+                                    name: "static",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Declaration",
+                                    loc: null,
+                                    property: "--color-primary",
+                                    value: {
+                                        type: "Raw",
+                                        value: " #ff0000",
+                                        loc: null
+                                    },
+                                    important: false
+                                }
+                            ]
+                        },
+                        loc: null
+                    }
+                ]
+            });
+        });
 
-			it("should parse @import with source, prefix and layer", () => {
-				const tree = toPlainObject(
-					parse(
-						'@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
-					),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "tailwindcss/utilities.css",
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "source",
-										children: [
-											{
-												type: "Identifier",
-												name: "none",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "prefix",
-										children: [
-											{
-												type: "Identifier",
-												name: "tw",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-									{
-										type: "Function",
-										name: "layer",
-										children: [
-											{
-												type: "Layer",
-												name: "utilities",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+        describe("Validation", () => {
+            [
+                "@theme { --color-primary: #ff0000; }",
+                "@theme inline { --color-primary: #ff0000; }",
+                "@theme static { --color-primary: #ff0000; }"
+            ].forEach((prelude) => {
+                it(`should allow valid prelude: ${prelude}`, () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("theme", tree.children[0].prelude);
+                    assert.equal(error, null);
+                });
+            });
 
-			it("should parse @import with layer", () => {
-				const tree = toPlainObject(parse('@import "./foo.css" layer;'));
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								children: [
-									{
-										loc: null,
-										type: "String",
-										value: "./foo.css",
-									},
-									{
-										loc: null,
-										name: "layer",
-										type: "Identifier",
-									},
-								],
-								loc: null,
-								type: "AtrulePrelude",
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+            [
+                "@theme colors { --color-primary: #ff0000; }",
+                "@theme inline static { --color-primary: #ff0000; }",
+                "@theme static inline { --color-primary: #ff0000; }"
+            ].forEach((prelude) => {
+                it(`should fail with invalid prelude: ${prelude}`, () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("theme", tree.children[0].prelude);
+                    assert.notEqual(error, null);
+                });
+            });
+        });
 
-			it("should parse @import with layer()", () => {
-				const tree = toPlainObject(
-					parse('@import "./foo.css" layer(utilities);'),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								children: [
-									{
-										loc: null,
-										type: "String",
-										value: "./foo.css",
-									},
-									{
-										children: [
-											{
-												loc: null,
-												name: "utilities",
-												type: "Layer",
-											},
-										],
-										loc: null,
-										name: "layer",
-										type: "Function",
-									},
-								],
-								loc: null,
-								type: "AtrulePrelude",
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+        it("should parse @theme wildcard custom property reset", () => {
+            const tree = toPlainObject(parse("@theme { --color-*: initial; }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "theme",
+                        prelude: null,
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Declaration",
+                                    loc: null,
+                                    property: "--color-*",
+                                    value: {
+                                        type: "Raw",
+                                        value: " initial",
+                                        loc: null
+                                    },
+                                    important: false
+                                }
+                            ]
+                        },
+                        loc: null
+                    }
+                ]
+            });
+        });
+    });
 
-			it("should parse @import with media query list", () => {
-				const tree = toPlainObject(
-					parse('@import url("bluish.css") print, screen;'),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								children: [
-									{
-										loc: null,
-										type: "Url",
-										value: "bluish.css",
-									},
-									{
-										children: [
-											{
-												condition: null,
-												loc: null,
-												mediaType: "print",
-												modifier: null,
-												type: "MediaQuery",
-											},
-											{
-												condition: null,
-												loc: null,
-												mediaType: "screen",
-												modifier: null,
-												type: "MediaQuery",
-											},
-										],
-										loc: null,
-										type: "MediaQueryList",
-									},
-								],
-								loc: null,
-								type: "AtrulePrelude",
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
+    describe("@source", () => {
+        describe("Parsing", () => {
+            it("should parse @source", () => {
+                const tree = toPlainObject(parse("@source '../node_modules/@acmecorp/ui-lib';"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "source",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "String",
+                                        value: "../node_modules/@acmecorp/ui-lib",
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
 
-			it("should parse @import with complex media query", () => {
-				const tree = toPlainObject(
-					parse(
-						'@import url("landscape.css") screen and (orientation: landscape);',
-					),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "import",
-							prelude: {
-								children: [
-									{
-										loc: null,
-										type: "Url",
-										value: "landscape.css",
-									},
-									{
-										children: [
-											{
-												condition: {
-													children: [
-														{
-															kind: "media",
-															loc: null,
-															name: "orientation",
-															type: "Feature",
-															value: {
-																loc: null,
-																name: "landscape",
-																type: "Identifier",
-															},
-														},
-													],
-													kind: "media",
-													loc: null,
-													type: "Condition",
-												},
-												loc: null,
-												mediaType: "screen",
-												modifier: null,
-												type: "MediaQuery",
-											},
-										],
-										loc: null,
-										type: "MediaQueryList",
-									},
-								],
-								loc: null,
-								type: "AtrulePrelude",
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
-		});
+            it("should parse @source not", () => {
+                const tree = toPlainObject(parse('@source not "../src/components/legacy";'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "source",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        type: "Identifier",
+                                        name: "not",
+                                        loc: null
+                                    },
+                                    {
+                                        type: "String",
+                                        value: "../src/components/legacy",
+                                        loc: null
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
 
-		describe("Validation", () => {
-			[
-				"@import 'tailwindcss';",
-				"@import url('test.css');",
-				"@import 'tailwindcss' prefix(tw);",
-				"@import 'tailwindcss' source('..');",
-				"@import 'tailwindcss' source(none);",
-				"@import 'tailwindcss' source(none) prefix(tw);",
-				'@import "tailwindcss/utilities.css" source(none) prefix(tw) layer(utilities);',
-				'@import "./foo.css" layer;',
-				'@import "./foo.css" layer(utilities);',
-				'@import url("bluish.css") print, screen;',
-				'@import url("landscape.css") screen and (orientation: landscape);',
-			].forEach(prelude => {
-				it("should allow valid prelude", () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"import",
-						tree.children[0].prelude,
-					);
-					assert.equal(error, null);
-				});
-			});
+            it("should parse @source inline()", () => {
+                const tree = toPlainObject(parse("@source inline('{hover:,}bg-red-{50,{100..900..100},950}');"));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "source",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        "children": [
+                                            {
+                                                "loc": null,
+                                                "type": "String",
+                                                "value": "{hover:,}bg-red-{50,{100..900..100},950}"
+                                            }
+                                        ],
+                                        "loc": null,
+                                        "name": "inline",
+                                        "type": "Function"
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
 
-			[
-				"@import 'foo' 'bar';",
-				"@import 'tailwindcss' print, screen prefix(tw);",
-				'@import url("landscape.css") screen and (orientation: landscape) layer(base);',
-				// todo: fail with these
-				// "@import 'tailwindcss' prefix(foo) prefix(bar);",
-				// "@import 'tailwindcss' prefix('foo');",
-				// "@import 'tailwindcss' prefix();",
-				// "@import 'tailwindcss' prefix;",
-				// "@import 'tailwindcss' source(foo);",
-				// "@import 'tailwindcss' source;",
-			].forEach(prelude => {
-				it("should fail with invalid prelude", () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"import",
-						tree.children[0].prelude,
-					);
-					assert.notEqual(error, null);
-				});
-			});
-		});
-	});
+            it("should parse @source not inline()", () => {
+                const tree = toPlainObject(parse('@source not inline("container");'));
+                assert.deepStrictEqual(tree, {
+                    type: "StyleSheet",
+                    loc: null,
+                    children: [
+                        {
+                            type: "Atrule",
+                            name: "source",
+                            prelude: {
+                                type: "AtrulePrelude",
+                                loc: null,
+                                children: [
+                                    {
+                                        "loc": null,
+                                        "name": "not",
+                                        "type": "Identifier"
+                                    },
+                                    {
+                                        "children": [
+                                            {
+                                                "loc": null,
+                                                "type": "String",
+                                                "value": "container"
+                                            }
+                                        ],
+                                        "loc": null,
+                                        "name": "inline",
+                                        "type": "Function"
+                                    }
+                                ]
+                            },
+                            block: null,
+                            loc: null
+                        }
+                    ]
+                });
+            });
+        });
 
-	describe("@config", () => {
-		it("should parse @config with a string value", () => {
-			const tree = toPlainObject(parse("@config 'tailwind.config.js';"));
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "config",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "String",
-									value: "tailwind.config.js",
-									loc: null,
-								},
-							],
-						},
-						block: null,
-						loc: null,
-					},
-				],
-			});
-		});
-	});
+        describe('Validation', () => {
+            [
+                "@source '../foo';",
+                '@source not "./bar";',
+                "@source inline('container');",
+                "@source not inline('container');",
+            ].forEach((prelude) => {
+                it("should allow valid prelude", () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("source", tree.children[0].prelude);
+                    assert.equal(error, null);
+                });
+            });
 
-	describe("@plugin", () => {
-		it("should parse @plugin with a string value", () => {
-			const tree = toPlainObject(
-				parse("@plugin 'tailwindcss/typography';"),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "plugin",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "String",
-									value: "tailwindcss/typography",
-									loc: null,
-								},
-							],
-						},
-						block: null,
-						loc: null,
-					},
-				],
-			});
-		});
-	});
-
-	describe("@theme", () => {
-		it("should parse @theme with inline prelude", () => {
-			const tree = toPlainObject(
-				parse("@theme inline { --color-primary: #ff0000; }"),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "theme",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "Identifier",
-									name: "inline",
-									loc: null,
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Declaration",
-									loc: null,
-									property: "--color-primary",
-									value: {
-										type: "Raw",
-										value: " #ff0000",
-										loc: null,
-									},
-									important: false,
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-
-		it("should parse @theme with static prelude", () => {
-			const tree = toPlainObject(
-				parse("@theme static { --color-primary: #ff0000; }"),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "theme",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "Identifier",
-									name: "static",
-									loc: null,
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Declaration",
-									loc: null,
-									property: "--color-primary",
-									value: {
-										type: "Raw",
-										value: " #ff0000",
-										loc: null,
-									},
-									important: false,
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-
-		describe("Validation", () => {
-			[
-				"@theme { --color-primary: #ff0000; }",
-				"@theme inline { --color-primary: #ff0000; }",
-				"@theme static { --color-primary: #ff0000; }",
-			].forEach(prelude => {
-				it(`should allow valid prelude: ${prelude}`, () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"theme",
-						tree.children[0].prelude,
-					);
-					assert.equal(error, null);
-				});
-			});
-
-			[
-				"@theme colors { --color-primary: #ff0000; }",
-				"@theme inline static { --color-primary: #ff0000; }",
-				"@theme static inline { --color-primary: #ff0000; }",
-			].forEach(prelude => {
-				it(`should fail with invalid prelude: ${prelude}`, () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"theme",
-						tree.children[0].prelude,
-					);
-					assert.notEqual(error, null);
-				});
-			});
-		});
-
-		it("should parse @theme wildcard custom property reset", () => {
-			const tree = toPlainObject(parse("@theme { --color-*: initial; }"));
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "theme",
-						prelude: null,
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Declaration",
-									loc: null,
-									property: "--color-*",
-									value: {
-										type: "Raw",
-										value: " initial",
-										loc: null,
-									},
-									important: false,
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-	});
-
-	describe("@source", () => {
-		describe("Parsing", () => {
-			it("should parse @source", () => {
-				const tree = toPlainObject(
-					parse("@source '../node_modules/@acmecorp/ui-lib';"),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "source",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "String",
-										value: "../node_modules/@acmecorp/ui-lib",
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
-
-			it("should parse @source not", () => {
-				const tree = toPlainObject(
-					parse('@source not "../src/components/legacy";'),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "source",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										type: "Identifier",
-										name: "not",
-										loc: null,
-									},
-									{
-										type: "String",
-										value: "../src/components/legacy",
-										loc: null,
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
-
-			it("should parse @source inline()", () => {
-				const tree = toPlainObject(
-					parse(
-						"@source inline('{hover:,}bg-red-{50,{100..900..100},950}');",
-					),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "source",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										children: [
-											{
-												loc: null,
-												type: "String",
-												value: "{hover:,}bg-red-{50,{100..900..100},950}",
-											},
-										],
-										loc: null,
-										name: "inline",
-										type: "Function",
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
-
-			it("should parse @source not inline()", () => {
-				const tree = toPlainObject(
-					parse('@source not inline("container");'),
-				);
-				assert.deepStrictEqual(tree, {
-					type: "StyleSheet",
-					loc: null,
-					children: [
-						{
-							type: "Atrule",
-							name: "source",
-							prelude: {
-								type: "AtrulePrelude",
-								loc: null,
-								children: [
-									{
-										loc: null,
-										name: "not",
-										type: "Identifier",
-									},
-									{
-										children: [
-											{
-												loc: null,
-												type: "String",
-												value: "container",
-											},
-										],
-										loc: null,
-										name: "inline",
-										type: "Function",
-									},
-								],
-							},
-							block: null,
-							loc: null,
-						},
-					],
-				});
-			});
-		});
-
-		describe("Validation", () => {
-			[
-				"@source '../foo';",
-				'@source not "./bar";',
-				"@source inline('container');",
-				"@source not inline('container');",
-			].forEach(prelude => {
-				it("should allow valid prelude", () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"source",
-						tree.children[0].prelude,
-					);
-					assert.equal(error, null);
-				});
-			});
-
-			[
-				"@source foo;",
-				"@source 10;",
-				"@source foo 'bar';",
-				"@source foo inline('bar');",
-				"@source not inline('bar') 'baz';",
-				"@source foo('bar');",
-			].forEach(prelude => {
-				it("should fail with invalid prelude", () => {
-					const tree = toPlainObject(parse(prelude));
-					const { error } = lexer.matchAtrulePrelude(
-						"source",
-						tree.children[0].prelude,
-					);
-					assert.notEqual(error, null);
-				});
-			});
-		});
-	});
+            [
+                "@source foo;",
+                "@source 10;",
+                "@source foo 'bar';",
+                "@source foo inline('bar');",
+                "@source not inline('bar') 'baz';",
+                "@source foo('bar');",
+            ].forEach((prelude) => {
+                it("should fail with invalid prelude", () => {
+                    const tree = toPlainObject(parse(prelude));
+                    const { error } = lexer.matchAtrulePrelude("source", tree.children[0].prelude);
+                    assert.notEqual(error, null);
+                });
+          });
+      });
+    });
 
 	describe("@utility", () => {
-		it("should parse @utility with a valid prelude", () => {
-			const tree = toPlainObject(
-				parse(
-					"@utility font-mono { font-feature-numeric: tabular-nums; }",
-				),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "utility",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "Identifier",
-									name: "font-mono",
-									loc: null,
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Declaration",
-									loc: null,
-									property: "font-feature-numeric",
-									value: {
-										type: "Value",
-										children: [
-											{
-												type: "Identifier",
-												name: "tabular-nums",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-									important: false,
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-	});
+        it("should parse @utility with a valid prelude", () => {
+            const tree = toPlainObject(
+                parse(
+                    "@utility font-mono { font-feature-numeric: tabular-nums; }",
+                ),
+            );
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "utility",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Identifier",
+                                    name: "font-mono",
+                                    loc: null,
+                                },
+                            ],
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Declaration",
+                                    loc: null,
+                                    property: "font-feature-numeric",
+                                    value: {
+                                        type: "Value",
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "tabular-nums",
+                                                loc: null,
+                                            },
+                                        ],
+                                        loc: null,
+                                    },
+                                    important: false,
+                                },
+                            ],
+                        },
+                        loc: null,
+                    },
+                ],
+            });
+        });
+    });
 
-	describe("@variant", () => {
-		it("should parse @variant with a valid prelude", () => {
-			const tree = toPlainObject(
-				parse("@variant hover { .example { color: blue; } }"),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "variant",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "Identifier",
-									name: "hover",
-									loc: null,
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Rule",
-									loc: null,
-									prelude: {
-										type: "SelectorList",
-										loc: null,
-										children: [
-											{
-												type: "Selector",
-												loc: null,
-												children: [
-													{
-														type: "ClassSelector",
-														name: "example",
-														loc: null,
-													},
-												],
-											},
-										],
-									},
-									block: {
-										type: "Block",
-										loc: null,
-										children: [
-											{
-												type: "Declaration",
-												loc: null,
-												property: "color",
-												value: {
-													type: "Value",
-													children: [
-														{
-															type: "Identifier",
-															name: "blue",
-															loc: null,
-														},
-													],
-													loc: null,
-												},
-												important: false,
-											},
-										],
-									},
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-	});
+    describe("@variant", () => {
+        it("should parse @variant with a valid prelude", () => {
+            const tree = toPlainObject(parse("@variant hover { .example { color: blue; } }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "variant",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Identifier",
+                                    name: "hover",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Rule",
+                                    loc: null,
+                                    prelude: {
+                                        type: "SelectorList",
+                                        loc: null,
+                                        children: [
+                                            {
+                                                type: "Selector",
+                                                loc: null,
+                                                children: [
+                                                    {
+                                                        type: "ClassSelector",
+                                                        name: "example",
+                                                        loc: null
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    block: {
+                                        type: "Block",
+                                        loc: null,
+                                        children: [
+                                            {
+                                                type: "Declaration",
+                                                loc: null,
+                                                property: "color",
+                                                value: {
+                                                    type: "Value",
+                                                    children: [
+                                                        {
+                                                            type: "Identifier",
+                                                            name: "blue",
+                                                            loc: null
+                                                        }
+                                                    ],
+                                                    loc: null
+                                                },
+                                                important: false
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        loc: null
+                    }
+                ]
+            });
+        });
+    });
 
-	describe("@custom-variant", () => {
-		it("should parse @custom-variant with an inline selector list", () => {
-			const tree = toPlainObject(
-				parse(
-					"@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
-				),
-			);
-			const atrule = tree.children[0];
+    describe("@custom-variant", () => {
+        it("should parse @custom-variant with an inline selector list", () => {
+            const tree = toPlainObject(parse("@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));"));
+            const atrule = tree.children[0];
 
-			assert.equal(atrule.type, "Atrule");
-			assert.equal(atrule.name, "custom-variant");
-			assert.equal(atrule.block, null);
-			assert.equal(atrule.prelude.type, "AtrulePrelude");
-			assert.equal(atrule.prelude.children.length, 2);
-			assert.equal(
-				atrule.prelude.children[1].value,
-				"(&:where([data-theme=dark], [data-theme=dark] *))",
-			);
-		});
+            assert.equal(atrule.type, "Atrule");
+            assert.equal(atrule.name, "custom-variant");
+            assert.equal(atrule.block, null);
+            assert.equal(atrule.prelude.type, "AtrulePrelude");
+            assert.equal(atrule.prelude.children.length, 2);
+            assert.equal(
+                atrule.prelude.children[1].value,
+                "(&:where([data-theme=dark], [data-theme=dark] *))",
+            );
+        });
 
-		it("should parse @custom-variant with a block body using @slot", () => {
-			const tree = toPlainObject(
-				parse(
-					'@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
-				),
-			);
-			const atrule = tree.children[0];
+        it("should parse @custom-variant with a block body using @slot", () => {
+            const tree = toPlainObject(parse('@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }'));
+            const atrule = tree.children[0];
 
-			assert.equal(atrule.type, "Atrule");
-			assert.equal(atrule.name, "custom-variant");
-			assert.equal(atrule.prelude.type, "AtrulePrelude");
-			assert.equal(atrule.prelude.children[0].name, "theme-midnight");
-			assert.equal(atrule.block.children[0].type, "Rule");
-			assert.equal(
-				atrule.block.children[0].block.children[0].name,
-				"slot",
-			);
-		});
+            assert.equal(atrule.type, "Atrule");
+            assert.equal(atrule.name, "custom-variant");
+            assert.equal(atrule.prelude.type, "AtrulePrelude");
+            assert.equal(atrule.prelude.children[0].name, "theme-midnight");
+            assert.equal(atrule.block.children[0].type, "Rule");
+            assert.equal(atrule.block.children[0].block.children[0].name, "slot");
+        });
 
-		it("should parse @custom-variant with a single inline selector", () => {
-			const tree = toPlainObject(
-				parse(
-					'@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
-				),
-			);
-			const atrule = tree.children[0];
+        it("should parse @custom-variant with a single inline selector", () => {
+            const tree = toPlainObject(parse('@custom-variant theme-midnight (&:where([data-theme="midnight"] *));'));
+            const atrule = tree.children[0];
 
-			assert.equal(atrule.type, "Atrule");
-			assert.equal(atrule.name, "custom-variant");
-			assert.equal(atrule.block, null);
-			assert.equal(atrule.prelude.type, "AtrulePrelude");
-			assert.equal(atrule.prelude.children.length, 2);
-			assert.equal(
-				atrule.prelude.children[1].value,
-				'(&:where([data-theme="midnight"] *))',
-			);
-		});
+            assert.equal(atrule.type, "Atrule");
+            assert.equal(atrule.name, "custom-variant");
+            assert.equal(atrule.block, null);
+            assert.equal(atrule.prelude.type, "AtrulePrelude");
+            assert.equal(atrule.prelude.children.length, 2);
+            assert.equal(atrule.prelude.children[1].value, '(&:where([data-theme="midnight"] *))');
+        });
 
-		it("should parse @custom-variant with nested at-rules in a block body", () => {
-			const tree = toPlainObject(
-				parse(
-					"@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
-				),
-			);
-			const atrule = tree.children[0];
+        it("should parse @custom-variant with nested at-rules in a block body", () => {
+            const tree = toPlainObject(parse("@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }"));
+            const atrule = tree.children[0];
 
-			assert.equal(atrule.type, "Atrule");
-			assert.equal(atrule.name, "custom-variant");
-			assert.equal(atrule.prelude.type, "AtrulePrelude");
-			assert.equal(atrule.prelude.children[0].name, "any-hover");
-			assert.equal(atrule.block.children[0].name, "media");
-			assert.equal(
-				atrule.block.children[0].block.children[0].type,
-				"Rule",
-			);
-		});
+            assert.equal(atrule.type, "Atrule");
+            assert.equal(atrule.name, "custom-variant");
+            assert.equal(atrule.prelude.type, "AtrulePrelude");
+            assert.equal(atrule.prelude.children[0].name, "any-hover");
+            assert.equal(atrule.block.children[0].name, "media");
+            assert.equal(atrule.block.children[0].block.children[0].type, "Rule");
+        });
 
-		describe("Validation", () => {
-			[
-				"@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
-				'@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
-				'@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
-				"@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
-			].forEach(cssRule => {
-				it(`should allow valid prelude: ${cssRule}`, () => {
-					const tree = toPlainObject(parse(cssRule));
-					const { error } = lexer.matchAtrulePrelude(
-						"custom-variant",
-						tree.children[0].prelude,
-					);
-					assert.equal(error, null);
-				});
-			});
-		});
-	});
+        describe("Validation", () => {
+            [
+                "@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));",
+                '@custom-variant theme-midnight { &:where([data-theme="midnight"] *) { @slot; } }',
+                '@custom-variant theme-midnight (&:where([data-theme="midnight"] *));',
+                "@custom-variant any-hover { @media (any-hover: hover) { &:hover { @slot; } } }",
+            ].forEach((cssRule) => {
+                it(`should allow valid prelude: ${cssRule}`, () => {
+                    const tree = toPlainObject(parse(cssRule));
+                    const { error } = lexer.matchAtrulePrelude("custom-variant", tree.children[0].prelude);
+                    assert.equal(error, null);
+                });
+            });
+        });
+    });
 
-	describe("@apply", () => {
-		it("should parse @apply with valid classes", () => {
-			const tree = toPlainObject(
-				parse(
-					".example { @apply bg-red-500 text-white focus:ring-3 grid-cols-[200px_auto]; }",
-				),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Rule",
-						loc: null,
-						prelude: {
-							type: "SelectorList",
-							loc: null,
-							children: [
-								{
-									type: "Selector",
-									loc: null,
-									children: [
-										{
-											type: "ClassSelector",
-											name: "example",
-											loc: null,
-										},
-									],
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Atrule",
-									name: "apply",
-									prelude: {
-										type: "AtrulePrelude",
-										loc: null,
-										children: [
-											{
-												type: "Identifier",
-												name: "bg-red-500",
-												loc: null,
-											},
-											{
-												type: "Identifier",
-												name: "text-white",
-												loc: null,
-											},
-											{
-												type: "TailwindUtilityClass",
-												loc: null,
-												variant: {
-													type: "Identifier",
-													name: "focus",
-													loc: null,
-												},
-												name: {
-													type: "Identifier",
-													name: "ring-3",
-													loc: null,
-												},
-											},
-											{
-												type: "TailwindUtilityClass",
-												loc: null,
-												variant: null,
-												name: {
-													type: "Identifier",
-													name: "grid-cols-[200px_auto]",
-													loc: null,
-												},
-											},
-										],
-									},
-									block: null,
-									loc: null,
-								},
-							],
-						},
-					},
-				],
-			});
-		});
+    describe("@apply", () => {
+        it("should parse @apply with valid classes", () => {
+            const tree = toPlainObject(parse(".example { @apply bg-red-500 text-white focus:ring-3 grid-cols-[200px_auto]; }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Rule",
+                        loc: null,
+                        prelude: {
+                            type: "SelectorList",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Selector",
+                                    loc: null,
+                                    children: [
+                                        {
+                                            type: "ClassSelector",
+                                            name: "example",
+                                            loc: null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Atrule",
+                                    name: "apply",
+                                    prelude: {
+                                        type: "AtrulePrelude",
+                                        loc: null,
+                                        children: [
+                                            {
+                                                type: "Identifier",
+                                                name: "bg-red-500",
+                                                loc: null
+                                            },
+                                            {
+                                                type: "Identifier",
+                                                name: "text-white",
+                                                loc: null
+                                            },
+                                            {
+                                                type: "TailwindUtilityClass",
+                                                loc: null,
+                                                variant: {
+                                                    type: "Identifier",
+                                                    name: "focus",
+                                                    loc: null
+                                                },
+                                                name: {
+                                                    type: "Identifier",
+                                                    name: "ring-3",
+                                                    loc: null
+                                                }
+                                            },
+                                            {
+                                                type: "TailwindUtilityClass",
+                                                loc: null,
+                                                variant: null,
+                                                name: {
+                                                    type: "Identifier",
+                                                    name: "grid-cols-[200px_auto]",
+                                                    loc: null
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    block: null,
+                                    loc: null
+                                }
+                            ]
+                        }
+                    }
+                ]
+            });
+        });
 
-		it("should parse @apply with responsive condition variants", () => {
-			assert.doesNotThrow(() => {
-				parse(".example { @apply sm:grid; }");
-			});
-		});
+        it("should parse @apply with responsive condition variants", () => {
+            assert.doesNotThrow(() => {
+                parse(".example { @apply sm:grid; }");
+            });
+        });
 
-		it("should parse @apply with slash notation for opacity modifiers", () => {
-			const testCases = [
-				"a { @apply outline-ring/50; }",
-				"a { @apply bg-blue-500/30; }",
-				"a { @apply border-gray-200/50; }",
-			];
+        it("should parse @apply with slash notation for opacity modifiers", () => {
+            const testCases = [
+                "a { @apply outline-ring/50; }",
+                "a { @apply bg-blue-500/30; }",
+                "a { @apply border-gray-200/50; }",
+            ];
 
-			testCases.forEach(testCase => {
-				assert.doesNotThrow(() => {
-					const result = parse(testCase);
-					assert.ok(result, `Should parse: ${testCase}`);
-				}, `Should not throw parsing errors for: ${testCase}`);
-			});
-		});
+            testCases.forEach((testCase) => {
+                assert.doesNotThrow(() => {
+                    const result = parse(testCase);
+                    assert.ok(result, `Should parse: ${testCase}`);
+                }, `Should not throw parsing errors for: ${testCase}`);
+            });
+        });
+        
+        it("should parse @apply with variants and slash notation", () => {
+            const testCases = [
+                "a { @apply hover:bg-blue-500/50; }",
+                "a { @apply focus:outline-ring/30; }",
+                "a { @apply active:border-red-500/25; }",
+            ];
+            
+            testCases.forEach((testCase) => {
+                assert.doesNotThrow(() => {
+                    const result = parse(testCase);
+                    assert.ok(result, `Should parse: ${testCase}`);
+                }, `Should not throw parsing errors for: ${testCase}`);
+            });
+        });
 
-		it("should parse @apply with variants and slash notation", () => {
-			const testCases = [
-				"a { @apply hover:bg-blue-500/50; }",
-				"a { @apply focus:outline-ring/30; }",
-				"a { @apply active:border-red-500/25; }",
-			];
-
-			testCases.forEach(testCase => {
-				assert.doesNotThrow(() => {
-					const result = parse(testCase);
-					assert.ok(result, `Should parse: ${testCase}`);
-				}, `Should not throw parsing errors for: ${testCase}`);
-			});
-		});
-
-		it("should parse @apply with square bracket arbitrary values", () => {
-			const testCases = [
-				"a { @apply grid-cols-[200px_auto]; }",
-				"a { @apply hover:grid-cols-[200px_auto]; }",
-			];
-
-			testCases.forEach(testCase => {
-				assert.doesNotThrow(() => {
-					const result = parse(testCase);
-					assert.ok(result, `Should parse: ${testCase}`);
-				}, `Should not throw parsing errors for: ${testCase}`);
-			});
-		});
-
-		it("should parse the original issue CSS without errors", () => {
-			const originalCSS = `
+        it("should parse @apply with square bracket arbitrary values", () => {
+            const testCases = [
+                "a { @apply grid-cols-[200px_auto]; }",
+                "a { @apply hover:grid-cols-[200px_auto]; }",
+            ];
+            
+            testCases.forEach((testCase) => {
+                assert.doesNotThrow(() => {
+                    const result = parse(testCase);
+                    assert.ok(result, `Should parse: ${testCase}`);
+                }, `Should not throw parsing errors for: ${testCase}`);
+            });
+        });
+        
+        it("should parse the original issue CSS without errors", () => {
+            const originalCSS = `
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -1318,144 +1231,126 @@ describe("Tailwind 4", function () {
   }
 }
             `;
+            
+            // The original issue was that this would throw:
+            // "Parsing error: Semicolon or block is expected"
+            // Now it should parse successfully
+            assert.doesNotThrow(() => {
+                const result = parse(originalCSS);
+                assert.ok(result, "Should return a valid AST");
+            }, "Should not throw parsing errors");
+        });
+    });
 
-			// The original issue was that this would throw:
-			// "Parsing error: Semicolon or block is expected"
-			// Now it should parse successfully
-			assert.doesNotThrow(() => {
-				const result = parse(originalCSS);
-				assert.ok(result, "Should return a valid AST");
-			}, "Should not throw parsing errors");
-		});
-	});
+    describe("@reference", () => {
+        it("should parse @reference with a valid prelude", () => {
+            const tree = toPlainObject(parse("@reference colors { primary: #00ff00; }"));
+            assert.deepStrictEqual(tree, {
+                type: "StyleSheet",
+                loc: null,
+                children: [
+                    {
+                        type: "Atrule",
+                        name: "reference",
+                        prelude: {
+                            type: "AtrulePrelude",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Identifier",
+                                    name: "colors",
+                                    loc: null
+                                }
+                            ]
+                        },
+                        block: {
+                            type: "Block",
+                            loc: null,
+                            children: [
+                                {
+                                    type: "Declaration",
+                                    loc: null,
+                                    property: "primary",
+                                    value: {
+                                        type: "Value",
+                                        children: [
+                                            {
+                                                type: "Hash",
+                                                value: "00ff00",
+                                                loc: null
+                                            }
+                                        ],
+                                        loc: null
+                                    },
+                                    important: false
+                                }
+                            ]
+                        },
+                        loc: null
+                    }
+                ]
+            });
+        });
+    });
+    
+    describe("Validation", () => {
+        describe("Type Validation", () => {
+            [
+                "--alpha(#000 / 50%)",
+                "--alpha(white / 70%)",
+                "--alpha(rgba(0, 0, 0, 0.5) / 1%)",
+            ].forEach((value) => {
+                it(`should validate type <tw-alpha> with ${value}`, () => {
+                    const tree = parse(value, { context: 'value' });
+                    assert.strictEqual(lexer.matchType("tw-alpha", tree).error, null);
+                });
 
-	describe("@reference", () => {
-		it("should parse @reference with a valid prelude", () => {
-			const tree = toPlainObject(
-				parse("@reference colors { primary: #00ff00; }"),
-			);
-			assert.deepStrictEqual(tree, {
-				type: "StyleSheet",
-				loc: null,
-				children: [
-					{
-						type: "Atrule",
-						name: "reference",
-						prelude: {
-							type: "AtrulePrelude",
-							loc: null,
-							children: [
-								{
-									type: "Identifier",
-									name: "colors",
-									loc: null,
-								},
-							],
-						},
-						block: {
-							type: "Block",
-							loc: null,
-							children: [
-								{
-									type: "Declaration",
-									loc: null,
-									property: "primary",
-									value: {
-										type: "Value",
-										children: [
-											{
-												type: "Hash",
-												value: "00ff00",
-												loc: null,
-											},
-										],
-										loc: null,
-									},
-									important: false,
-								},
-							],
-						},
-						loc: null,
-					},
-				],
-			});
-		});
-	});
+                it(`should validate type <tw-any-color> with ${value}`, () => {
+                    const tree = parse(value, { context: 'value' });
+                    assert.strictEqual(lexer.matchType("tw-any-color", tree).error, null);
+                });
+            });
+            
+            [
+                "--spacing(4)",
+                "--spacing(12)",
+                "--spacing(0.5)",
+            ].forEach((value) => {
+                it(`should validate type <tw-spacing> with ${value}`, () => {
+                    const tree = parse(value, { context: 'value' });
+                    assert.strictEqual(lexer.matchType("tw-spacing", tree).error, null);
+                });
 
-	describe("Validation", () => {
-		describe("Type Validation", () => {
-			[
-				"--alpha(#000 / 50%)",
-				"--alpha(white / 70%)",
-				"--alpha(rgba(0, 0, 0, 0.5) / 1%)",
-			].forEach(value => {
-				it(`should validate type <tw-alpha> with ${value}`, () => {
-					const tree = parse(value, { context: "value" });
-					assert.strictEqual(
-						lexer.matchType("tw-alpha", tree).error,
-						null,
-					);
-				});
+                it(`should validate type <tw-any-spacing> with ${value}`, () => {
+                    const tree = parse(value, { context: 'value' });
+                    assert.strictEqual(lexer.matchType("tw-any-spacing", tree).error, null);
+                });
+            });
+        });
+        
+        describe("Property Validation", () => {
+            
+            it("should validate margin: --spacing(4)", () => {
+                const tree = toPlainObject(parse("a { margin: --spacing(4); }"));
+                const { error } = lexer.matchDeclaration(tree.children[0].block.children[0]);
+                assert.strictEqual(error, null);
+            });
+            
+            it("should validate color: --alpha(#000 / 50%)", () => {
+                const tree = toPlainObject(parse("a { color: --alpha(#000 / 50%); }"));
+                const { error } = lexer.matchDeclaration(tree.children[0].block.children[0]);
+                assert.strictEqual(error, null);
+            });
+            
+        });
+    });
 
-				it(`should validate type <tw-any-color> with ${value}`, () => {
-					const tree = parse(value, { context: "value" });
-					assert.strictEqual(
-						lexer.matchType("tw-any-color", tree).error,
-						null,
-					);
-				});
-			});
-
-			["--spacing(4)", "--spacing(12)", "--spacing(0.5)"].forEach(
-				value => {
-					it(`should validate type <tw-spacing> with ${value}`, () => {
-						const tree = parse(value, { context: "value" });
-						assert.strictEqual(
-							lexer.matchType("tw-spacing", tree).error,
-							null,
-						);
-					});
-
-					it(`should validate type <tw-any-spacing> with ${value}`, () => {
-						const tree = parse(value, { context: "value" });
-						assert.strictEqual(
-							lexer.matchType("tw-any-spacing", tree).error,
-							null,
-						);
-					});
-				},
-			);
-		});
-
-		describe("Property Validation", () => {
-			it("should validate margin: --spacing(4)", () => {
-				const tree = toPlainObject(
-					parse("a { margin: --spacing(4); }"),
-				);
-				const { error } = lexer.matchDeclaration(
-					tree.children[0].block.children[0],
-				);
-				assert.strictEqual(error, null);
-			});
-
-			it("should validate color: --alpha(#000 / 50%)", () => {
-				const tree = toPlainObject(
-					parse("a { color: --alpha(#000 / 50%); }"),
-				);
-				const { error } = lexer.matchDeclaration(
-					tree.children[0].block.children[0],
-				);
-				assert.strictEqual(error, null);
-			});
-		});
-	});
-
-	describe("Canonical Tailwind 4 File", () => {
-		it("should parse a canonical Tailwind 4 file", async () => {
-			const file = await fs.readFile(filename, "utf8");
-			const tree = toPlainObject(parse(file));
-
-			assert.strictEqual(tree.type, "StyleSheet");
-		});
-	});
+    describe("Canonical Tailwind 4 File", () => {
+        it("should parse a canonical Tailwind 4 file", async () => {
+            const file = await fs.readFile(filename, "utf8");
+            const tree = toPlainObject(parse(file));
+            
+            assert.strictEqual(tree.type, "StyleSheet");
+        });
+    });
 });


### PR DESCRIPTION
**Problem**: The eslint/css rule `no-invalid-at-rules` uses the `descriptor`s of an at-rule for its validation but for `@utility` they are missing.

**Solution**: Add `prev.properties` as `descriptors` similar to other at-rules for the `@utility` at-rule.


Refs [eslint/css#433](https://github.com/eslint/css/issues/433)